### PR TITLE
Pass jQuery's AMD module to the factory when on AMD context

### DIFF
--- a/src/jqfactory.js
+++ b/src/jqfactory.js
@@ -5,8 +5,8 @@
     'use strict';
     if (typeof define === 'function' && define.amd) {
         // An AMD loader is on the page. Register jqfactory as a named AMD module.
-        define('jqfactory', ['jquery'], function() {
-            jqfactory(window.jQuery, window, document);
+        define('jqfactory', ['jquery'], function($) {
+            jqfactory($, window, document);
         });
     } else {
         // An AMD loader is not on the page.


### PR DESCRIPTION
When defining jqfactory as an AMD module, the jQuery dependency isn't being passed to the factory.
This can lead to issues if more than one jQuery instance is on the page.
