### PR TITLE
Fix API methods only called for the first item.

### DIFF
--- a/src/jqfactory.js
+++ b/src/jqfactory.js
@@ -84,9 +84,10 @@
                 if (existingInstance) {
                     existingInstance._init.apply(existingInstance, arguments);
                     if($.type(firstArg) === 'string') {
-                        args.shift();
+                        var instanceArgs = slice.call(args);
+                        instanceArgs.shift();
                         if($.isFunction(existingInstance[firstArg])) {
-                            existingInstance[firstArg].apply(existingInstance, args);
+                            existingInstance[firstArg].apply(existingInstance, instanceArgs);
                         }
                     }
                     return;

--- a/src/jqfactory.js
+++ b/src/jqfactory.js
@@ -121,18 +121,19 @@
                 if (!$.fn[namespaceName]) {
                     $.fn[namespaceName] = function Namespace(context) {
                         if (this instanceof Namespace) {
+                            var self = this;
                             this.__namespace_context__ = context;
+                            $.each(namespaceFuncs, function(closureName, closure) {
+                                self[closureName] = function() {
+                                    return closure.apply(this.__namespace_context__, arguments);
+                                };
+                            });
                         }
                         else {
                             return new Namespace(this);
                         }
                     };
                 }
-                $.each(namespaceFuncs, function(closureName, closure) {
-                    $.fn[namespaceName].prototype[closureName] = function() {
-                        return closure.apply(this.__namespace_context__, arguments);
-                    };
-                });
             },
             postRender: function(rendered, args) {
                 var widget = this;


### PR DESCRIPTION
Example...

``` html
<a href="#">Item #1</a>
<a href="#">Item #2</a>
```

``` javascript
 $('a').pluginName('doSomethig');
```

...only invokes doSomething on the first anchor.
