### PR TITLE
Fix extending Namespace prototype not working on IE8

### DIFF
--- a/src/jqfactory.js
+++ b/src/jqfactory.js
@@ -84,9 +84,10 @@
                 if (existingInstance) {
                     existingInstance._init.apply(existingInstance, arguments);
                     if($.type(firstArg) === 'string') {
-                        args.shift();
+                        var instanceArgs = slice.call(args);
+                        instanceArgs.shift();
                         if($.isFunction(existingInstance[firstArg])) {
-                            existingInstance[firstArg].apply(existingInstance, args);
+                            existingInstance[firstArg].apply(existingInstance, instanceArgs);
                         }
                     }
                     return;

--- a/src/jqfactory.js
+++ b/src/jqfactory.js
@@ -121,18 +121,19 @@
                 if (!$.fn[namespaceName]) {
                     $.fn[namespaceName] = function Namespace(context) {
                         if (this instanceof Namespace) {
+                            var self = this;
                             this.__namespace_context__ = context;
+                            $.each(namespaceFuncs, function(closureName, closure) {
+                                self[closureName] = function() {
+                                    return closure.apply(this.__namespace_context__, arguments);
+                                };
+                            });
                         }
                         else {
                             return new Namespace(this);
                         }
                     };
                 }
-                $.each(namespaceFuncs, function(closureName, closure) {
-                    $.fn[namespaceName].prototype[closureName] = function() {
-                        return closure.apply(this.__namespace_context__, arguments);
-                    };
-                });
             },
             postRender: function(rendered, args) {
                 var widget = this;


### PR DESCRIPTION
It seems IE8 is not to keen on extending prototypes in some circumstances. It spills JS errors when using the factory with namespaces on.

Not sure my solution is the best way, but it works :)
You can try it with these in **IE8**:

not working: http://codepen.io/andrefgneves/full/kBLzu
working: http://codepen.io/andrefgneves/full/DjHLC
